### PR TITLE
Revamped commands and added alt. method for commands

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/rowan-chatbot.iml" filepath="$PROJECT_DIR$/.idea/rowan-chatbot.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/rowan-chatbot.iml
+++ b/.idea/rowan-chatbot.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/commands/bot.js
+++ b/commands/bot.js
@@ -1,0 +1,18 @@
+const {MessageEmbed} = require("discord.js");
+exports.run = async (client) => {
+    const embed = new MessageEmbed()
+        .setColor(generateRandomColour())
+        .setAuthor({ name: 'Rowan Chatbot', iconURL: 'https://i.imgur.com/rotM2an.png' })
+        .setDescription('This bot was made for Software Engineering during the Spring 2022 semester. It is made by Vince, Mura, Avery, Joe, Tristan, & Zach. The GitHub link can be found here: https://github.com/hungry-franklin-257fd8/rowan-chatbot.')
+        .setTimestamp()
+        .setFooter({text: `Made with '\u2665'`});
+    return { embeds: [embed] };
+}
+
+function generateRandomColour()
+{
+    return `#${(Math.random() * 0xFFFFFF << 0).toString(16).padStart(6, '0')}`;
+}
+
+exports.name = "bot";
+exports.description = "returns information about Rowan Chatbot";

--- a/commands/campus.js
+++ b/commands/campus.js
@@ -1,0 +1,22 @@
+const {MessageEmbed} = require("discord.js");
+
+exports.run = async (client) => {
+    const embed = new MessageEmbed()
+        .setColor(generateRandomColour())
+        .setTitle('Rowan University Campus')
+        .setURL('https://www.rowan.edu/about/visiting/main.html')
+        .setAuthor({ name: 'Rowan Campus', iconURL: 'https://i.imgur.com/UwP2r7v.png', url: 'https://www.rowan.edu/about/visiting/main.html' })
+        .setDescription('Find information about the campus & surrounding buildings')
+        .setThumbnail('https://i.imgur.com/UwP2r7v.png')
+        .setFooter({text: `Made with '\u2665'`})
+        .setTimestamp();
+    return { embeds: [embed] };
+
+    function generateRandomColour()
+    {
+        return `#${(Math.random() * 0xFFFFFF << 0).toString(16).padStart(6, '0')}`;
+    }
+}
+
+exports.name = "campus";
+exports.description = "returns information about Rowan campus & surrounding buildings";

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,0 +1,38 @@
+const {MessageEmbed} = require("discord.js");
+const fs = require("fs");
+
+exports.run = async (client) => {
+    let descriptionBuilder = "";
+    const files = fs.readdirSync("./commands").filter(file => file.endsWith(".js"));
+    console.log(files);
+    try {
+        for(const file of files) {
+            let cmd = require(`./${file}`);
+            descriptionBuilder = descriptionBuilder + `\`/${cmd.name}\`` + " — " + `${cmd.description}` + "\n";
+            //console.log(descriptionBuilder);
+        }
+    }
+    catch (err) {
+        console.log("Error when reading command json:", err);
+    }
+    try {
+        const embed = new MessageEmbed()
+            .setColor(generateRandomColour())
+            .setDescription(`${descriptionBuilder}`)
+            .setTimestamp()
+            .setFooter({text: `Made with '\u2665'`});
+        //console.log(embed);
+        return {embeds: [embed]}
+    } catch (e) {
+        console.error(e);
+        console.error("Problem while running help!");
+    }
+
+    function generateRandomColour()
+    {
+        return `#${(Math.random() * 0xFFFFFF << 0).toString(16).padStart(6, '0')}`;
+    }
+}
+
+exports.name = "help";
+exports.description = "returns list of available Chatbot commands";

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -5,22 +5,27 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9')
+const fs = require("fs");
 require('dotenv').config();
 const TOKEN = process.env.TOKEN;
 const CLIENT_ID = process.env.CLIENT_ID;
 const GUILD_ID = process.env.GUILD_ID;
-const commands = [
-    new SlashCommandBuilder().setName('help').setDescription('Replies with helpful dialogue about the Bot.'),
-    new SlashCommandBuilder().setName('university').setDescription('Replies with information about Rowan.'),
-    new SlashCommandBuilder().setName('campus').setDescription('Replies with helpful link about the Rowan campus.'),
-    new SlashCommandBuilder().setName('bot').setDescription('Replies with helpful link about the Rowan Chatbot.')
-].map(command => command.toJSON());
+const commands = [];
+const commandFiles = fs.readdirSync('./commands').filter(file => file.endsWith('.js'));
 const rest = new REST({ version: '9' }).setToken(TOKEN);
 
 /* =================================+
  |    SETS BOT COMMANDS TO GUILD    |
  * =================================+
 */
-rest.put(Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID), { body: commands })
-    .then(() => console.log('Successfully registered application commands.'))
-    .catch(console.error);
+
+for (const file of commandFiles) {
+    const command = require(`./commands/${file}`);
+    commands.push(command.data.toJSON());
+}
+
+(async () => {
+        await rest.put(Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID), {body: commands})
+            .then(() => console.log('Successfully registered application commands.'))
+            .catch(console.error);
+})();

--- a/events/interactionCreate.js
+++ b/events/interactionCreate.js
@@ -1,0 +1,8 @@
+module.exports = async (client, interaction) => {
+    // begone
+    if (!interaction.isCommand()) return;
+
+    const cmd = client.commands.get(interaction.commandName);
+
+    await interaction.reply(await cmd.run(client));
+}

--- a/events/messageCreate.js
+++ b/events/messageCreate.js
@@ -1,0 +1,17 @@
+module.exports = async (client, message) => {
+    // begone bots
+    if (message.author.bot) return;
+
+    // ignore non-prefixed msgs
+    if (message.content.indexOf(client.config.prefix) !== 0) return;
+
+    const args = message.content.slice(client.config.prefix.length).trim().split(/ +/g);
+    // ^ whitespace split using regex
+    const command = args.shift().toLowerCase();
+
+    const cmd = client.commands.get(command);
+
+    if (!cmd) return;
+
+    await message.reply(await cmd.run(client));
+}

--- a/structs/generateColor.js
+++ b/structs/generateColor.js
@@ -1,0 +1,6 @@
+function generateRandomColour()
+{
+    return `#${(Math.random() * 0xFFFFFF << 0).toString(16).padStart(6, '0')}`;
+}
+
+module.exports = generateRandomColour();


### PR DESCRIPTION
Checks for both `config.json` and `.env` were added in case there are platform issues encountered (for some reason, it was inconsistent for me).
The bot will check for new commands first thing by enumerating a list of .js files in the new `./commands` directory. It will also check for new events to handle in the new `./events` directory. So far, it only checks for new messages (uses the prefix assigned in the `config.json` file) and interactions that are caused by commands.
Each command technically requires no parameters, so for a future fix and for new commands, no parameters need be passed. However, the events still require a client and message/interaction parameter to send a reply.
`SlashCommandBuilder` was dropped, but I'm unsure of the side effects since the guild already contains the descriptions for each command.
The help command will also enumerate the command list and display them to the user as more commands are added.