### PR TITLE
Made Changes to Way Arguments are Loaded

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -22,8 +22,16 @@ for (const file of commandFiles) {
     const command = require(`./commands/${file}`);
     const slashCommand = new SlashCommandBuilder().setName(command.name).setDescription(command.description);
     if (command.args) {
-        slashCommand.addStringOption(option =>
-        option.setName(command.args).setDescription("filler").setRequired(false));
+        if (command.args.constructor.name == "Array") {
+            for (comm in command.args) {
+                console.log(comm);
+                slashCommand.addStringOption(option =>
+                    option.setName(command.args[comm].name).setDescription(command.args[comm].description).setRequired(command.args[comm].required));
+            }
+        } else {
+            slashCommand.addStringOption(option =>
+            option.setName(command.args).setDescription("Input").setRequired(false));
+        }
     }
     commands.push(slashCommand);
 }


### PR DESCRIPTION
Made Changes to Way Arguments are Loaded
All commands still work the way that they are

Multiple args and descriptions for args can be set in this format 
You can also set args to be required

exports.args = [{"name":"arg1", "description":"desc of arg1","required":false},
                {"name":"arg2", "description":"desc of arg1","required":false}];

They are still all string args but I think that's fine because you can still just input numbers 